### PR TITLE
Fixes for Read the Docs

### DIFF
--- a/{{cookiecutter.project_name}}/.readthedocs.yml
+++ b/{{cookiecutter.project_name}}/.readthedocs.yml
@@ -1,0 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+

--- a/{{cookiecutter.project_name}}/CONTRIBUTING.md
+++ b/{{cookiecutter.project_name}}/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 
 ## Dependencies
 
-We use [`poetry`](https://github.com/python-poetry/poetry) to manage the dependencies.
+We use [poetry](https://github.com/python-poetry/poetry) to manage the dependencies.
 
 To install them you would need to run `install` command:
 
@@ -22,7 +22,7 @@ Run `make test` to run everything we have!
 ## Tests
 
 We use `pytest` and `flake8` for quality control.
-We also use [`wemake_python_styleguide`](https://github.com/wemake-services/wemake-python-styleguide) to enforce the code quality.
+We also use [wemake_python_styleguide](https://github.com/wemake-services/wemake-python-styleguide) to enforce the code quality.
 
 To run all tests:
 

--- a/{{cookiecutter.project_name}}/docs/requirements.txt
+++ b/{{cookiecutter.project_name}}/docs/requirements.txt
@@ -1,8 +1,8 @@
 # This file is used to setup env
 # to generate documentation.
 
-sphinx==2.3.0
-sphinx_autodoc_typehints==1.10.3
+sphinx==2.3.1
+sphinx-autodoc-typehints==1.10.3
 recommonmark==0.6.0
 m2r==0.2.1
 tomlkit==0.5.8


### PR DESCRIPTION
1. Bump docs requirements and make name of `sphinx-autodoc-typehints` match the [PyPI style](https://pypi.org/project/sphinx-autodoc-typehints/).

2. Add `.readthedocs.yml` config so it explicitly uses `docs/requirements.txt` and not `requirements.txt` from repo root (if it is present). It was useful for me because I still keep `requirements.txt` in repo root exported from Poetry for Heroku Python Buildpack auto-deploy.

3. Remove markdown (CommonMark I suppose) syntax from `CONTRIBUTING.md` that is not supported in mdinclude of RST/Sphinx, because it was rendered incorrectly in Read the Docs.