### PR TITLE
#89 add .venv/bin to $PATH

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/test.yml
@@ -35,11 +35,12 @@ jobs:
     - name: Run checks
       run: |
         source "$HOME/.poetry/env"
+        export PATH="$(pwd)/.venv/bin:$PATH"
         make test
-        
+
     # Uncomment these lines if you wish to upload coverage to codecov:
     # https://codecov.io/
-    # - name: Upload coverage to Codecov  
+    # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@v1
     #   with:
     #     file: ./coverage.xml


### PR DESCRIPTION
Closes #89 

This helps Github workflow to succeed.