### PR TITLE
Remove recommonmark

### DIFF
--- a/{{cookiecutter.project_name}}/docs/requirements.txt
+++ b/{{cookiecutter.project_name}}/docs/requirements.txt
@@ -3,7 +3,6 @@
 
 sphinx==3.3.0
 sphinx-autodoc-typehints==1.11.1
-recommonmark==0.7.1
 m2r2==0.2.5
 tomlkit==0.7.0
 


### PR DESCRIPTION
Removes unneeded python requirement for `recommonmark` module. So it won't bother developers and dependabot =)

Fixes #203