### PR TITLE
Fix project name validation error text

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -12,7 +12,8 @@ def validate_project_name():
     This validator is used to ensure that `project_name` is valid.
 
     Valid inputs starts with the lowercase letter.
-    Followed by any lowercase letters, numbers or underscores.
+    Followed by any lowercase letters, numbers or hyphens.
+    Ends with a lowercase letter or number.
 
     Valid example: `school_project3`.
     """
@@ -21,8 +22,11 @@ def validate_project_name():
         message = [
             'ERROR: The project slug {0} is not a valid Python module name.',
             'Start with a lowercase letter.',
-            'Followed by any lowercase letters, numbers or underscores.',
+            'Followed by any lowercase letters, numbers or hyphens (-).',
+            'End with a lowercase letter or number.',
         ]
+        if '_' in MODULE_NAME:
+            message.append('Do not use underscores (_) in your project name.')
         raise ValueError(' '.join(message).format(MODULE_NAME))
 
 


### PR DESCRIPTION
Fixes #96

```
» cookiecutter gh:wemake-services/wemake-python-package      
project_name [my-awesome-project]: first_project
organization [wemake.services]: x5_school
project_description [This is how python package should look like!]: Test
license [MIT]:   
ERROR: The project slug first_project is not a valid Python module name. Start with a 
lowercase letter. Followed by any lowercase letters, numbers or underscores.
ERROR: Stopping generation because pre_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```

Changed to

```
» cookiecutter gh:vitkhab/wemake-python-package --checkout fix_project_name_validation_error_text
project_name [my-awesome-project]: first_project
organization [wemake.services]: x5_school
project_description [This is how python package should look like!]: Test
license [MIT]:   
ERROR: The project slug test_project is not a valid Python module name. Start with a
lowercase letter. Followed by any lowercase letters, numbers or hyphens (-). End with a
lowercase letter or number. Do not use underscores (_) in your project name.
ERROR: Stopping generation because pre_gen_project hook script didn't exit successfully
Hook script failed (exit status: 1)
```

`Do not use underscores (_) in your project name.` part is added only if there were underscores in the input.