### PR TITLE
Current year when generating docs

### DIFF
--- a/{{cookiecutter.project_name}}/docs/conf.py
+++ b/{{cookiecutter.project_name}}/docs/conf.py
@@ -29,7 +29,7 @@ def _get_project_meta():
 
 pkg_meta = _get_project_meta()
 project = str(pkg_meta['name'])
-copyright = '2020, {{ cookiecutter.organization }}'  # noqa: WPS125
+copyright = '{% now "local", "%Y" %}, {{ cookiecutter.organization }}'  # noqa: WPS125
 author = '{{ cookiecutter.organization }}'
 
 # The short X.Y version


### PR DESCRIPTION
The value `2020` was hardcoded, I propose to calculate the year dynamically when generating the project.

Current date and time using [jinja2-time](https://github.com/hackebrot/jinja2-time), which comes with cookiecutter.