### PR TITLE
Specifying in README.md that 'organization' better be github 'username'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,16 @@ Then, create a project itself:
 cookiecutter gh:wemake-services/wemake-python-package
 ```
 
+In order for the github actions to work smoothly (ie badge), you must, during the setup, use your github username in the `organization` field.
+```bash
+project_name [my-awesome-project]: foo-project
+organization [wemake.services]: <github_username>
+```
+
 
 ## Projects using it
 
-Here's [a nice list of real-life open-source usages](https://github.com/search?q=wemake-python-package&type=Code) 
+Here's [a nice list of real-life open-source usages](https://github.com/search?q=wemake-python-package&type=Code)
 of this template.
 
 


### PR DESCRIPTION
 Made change in README.md to specify that in order for the GitHub action to work properly, the github username needs to be used in the `organization` field during setup. which is not very clear at the moment.

Not being familiar with github actions it took me a while to figure out why the github badge `test: passing` was not working. And after watching at [list of real-life open-source usages](https://github.com/search?q=wemake-python-package&type=Code) I noticed that the vast majority have the test badge broken too. 