### PR TITLE
added the generation of pytest coverage.xml file required by the codecov/codecov-action@v1

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -9,6 +9,7 @@ lint:
 .PHONY: unit
 unit:
 	poetry run pytest
+	poetry run pytest --cov=./ --cov-report=xml
 
 .PHONY: package
 package:


### PR DESCRIPTION
As I said before I'm not so familiar with the cookiecutter & GitHub actions ecosystem so I'm not so sure how it supposed to be done. But the github action `codecov/codecov-action@v1` need the file `./coverage.xml` which is not generated (?) without the line I added in the `makefile`:
```
poetry run pytest --cov=./ --cov-report=xml
```
With that in place my `codcov` badge finally gets generated :+1: