### PR TITLE
Make ./docs/Makefile targets available in ./Makefile

### DIFF
--- a/{{cookiecutter.project_name}}/Makefile
+++ b/{{cookiecutter.project_name}}/Makefile
@@ -19,3 +19,6 @@ package:
 .PHONY: test
 test: lint package unit
 
+.DEFAULT:
+	@cd docs && $(MAKE) $@
+


### PR DESCRIPTION
Closes https://github.com/wemake-services/wemake-python-package/issues/77

> Since I figured out how to make all ./docs/Makefile targets available without boilerplate :-)

./docs/Makefile, add at end of file:
```
.DEFAULT:
        @cd docs && $(MAKE) $@
```

**Usage:**
- `make unit` # We know this
- `make html` # Works now directly in the root directory of the package
- `make pdf` # So does this 
